### PR TITLE
Support for Ruby on Rails 8 enum argument passing.

### DIFF
--- a/exnum.gemspec
+++ b/exnum.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activerecord', "~> 7.0"
+  spec.add_dependency 'activerecord', ">= 7.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/exnum/version.rb
+++ b/lib/exnum/version.rb
@@ -1,3 +1,3 @@
 module Exnum
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
In Rails 8, we must pass enum arguments with the new syntax.
https://github.com/rails/rails/pull/41328

I have modified the code to follow it.

If you use Rails 8 or later, you should exnum v0.4.0 or later.
If you use Rails 6 or earlier, you should exnum v0.3.1 or earlier.